### PR TITLE
멤버십/티켓/충전 자동 상태 변화 메서드 수정

### DIFF
--- a/backend/src/main/java/com/team/MMSValleyBall/repository/TicketRepository.java
+++ b/backend/src/main/java/com/team/MMSValleyBall/repository/TicketRepository.java
@@ -1,8 +1,6 @@
 package com.team.MMSValleyBall.repository;
 
-import com.team.MMSValleyBall.entity.MembershipSales;
 import com.team.MMSValleyBall.entity.Ticket;
-import com.team.MMSValleyBall.enums.MembershipSalesStatus;
 import com.team.MMSValleyBall.enums.TicketStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,8 +11,13 @@ import java.util.List;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
     // 티켓 예매 테이블: match_date가 오늘 날짜인 티켓을 찾고, 아직 CONFIRMED 상태가 아닌 경우 상태를 업데이트
-//    List<Ticket> findByTicketStatusAndMatchDateBetween(TicketStatus ticketStatus, LocalDateTime startDate, LocalDateTime endDate);
-//    List<Ticket> findByTicketStatusAndTicketCreateAtBefore(TicketStatus ticketStatus, LocalDateTime oneDayAgo);
+    @Query("SELECT t FROM Ticket t " +
+            "JOIN t.ticketMatch m " +
+            "WHERE m.matchDate = :matchDate AND t.ticketStatus <> :ticketStatus " +
+            "ORDER BY t.ticketId ASC")
+    List<Ticket> findTicketsByMatchDateAndStatus(@Param("matchDate") LocalDateTime matchDate,
+                                                 @Param("ticketStatus") TicketStatus ticketStatus);
+////    List<Ticket> findByTicketStatusAndTicketCreateAtBefore(TicketStatus ticketStatus, LocalDateTime oneDayAgo);
 
     //구역별 잔여좌석 조회 쿼리문
     @Query("SELECT s.seatId AS seatId, " +

--- a/backend/src/main/java/com/team/MMSValleyBall/service/AutoStatusSystemService.java
+++ b/backend/src/main/java/com/team/MMSValleyBall/service/AutoStatusSystemService.java
@@ -41,39 +41,42 @@ public class AutoStatusSystemService {
         // 충전: 현재 서버 시간 기준으로 7일이 지나면 CONFIRMED로 상태 변경됨
         LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
         List<Payment> payments = paymentRepository.findByPaymentStatusAndPaymentCreateAtBefore(PaymentStatus.COMPLETED, sevenDaysAgo);
-
+        System.out.println("payments"+payments);
         for (Payment payment : payments) {
-            payment.setPaymentStatus(PaymentStatus.CONFIRMED);
-            payment.setPaymentUpdateAt(LocalDateTime.now());
-            paymentRepository.save(payment);
-            log.info("Updated payment status for payment ID: {}", payment.getPaymentId());
+            if (payment.getPaymentStatus() == PaymentStatus.COMPLETED) {
+                payment.setPaymentStatus(PaymentStatus.CONFIRMED);
+                payment.setPaymentUpdateAt(LocalDateTime.now());
+                paymentRepository.save(payment);
+                log.info("Updated payment status for payment ID: {}", payment.getPaymentId());
+            }
         }
 
         // 멤버십: 현재 서버 시간 기준으로 7일이 지나면 CONFIRMED로 상태 변경됨
         List<MembershipSales> membershipSalesList = membershipSalesRepository.findByMembershipSalesStatusAndMembershipSalesCreateAtBefore(MembershipSalesStatus.CONFIRMED, sevenDaysAgo);
-
+        System.out.println("membershipSalesList"+membershipSalesList);
         for (MembershipSales membershipSales : membershipSalesList) {
-            membershipSales.setMembershipSalesStatus(MembershipSalesStatus.CONFIRMED);
-            membershipSales.setMembershipSalesUpdateAt(LocalDateTime.now());
-            membershipSalesRepository.save(membershipSales);
-            log.info("Updated membership sales status for ID: {}", membershipSales.getMembershipSalesId());
+            if (membershipSales.getMembershipSalesStatus() == MembershipSalesStatus.PURCHASE) {
+                membershipSales.setMembershipSalesStatus(MembershipSalesStatus.CONFIRMED);
+                membershipSales.setMembershipSalesUpdateAt(LocalDateTime.now());
+                membershipSalesRepository.save(membershipSales);
+                log.info("Updated membership sales status for ID: {}", membershipSales.getMembershipSalesId());
+            }
         }
 
         // 티켓: match_date가 오늘 날짜인 티켓을 찾고, 아직 CONFIRMED 상태가 아닌 경우 상태를 업데이트
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime midnightToday = now.toLocalDate().atStartOfDay(); // 오늘 자정 (00:00)
-        LocalDateTime midnightTomorrow = midnightToday.plusDays(1); // 다음 날 자정 (24:00)
 
-//        List<Ticket> tickets = ticketRepository.findByTicketStatusAndMatchDateBetween(TicketStatus.CONFIRMED, midnightToday, midnightTomorrow);
-//
-//        for (Ticket ticket : tickets) {
-//            if (ticket.getTicketStatus() != TicketStatus.CONFIRMED) {
-//                ticket.setTicketStatus(TicketStatus.CONFIRMED);
-//                ticket.setTicketUpdateAt(LocalDateTime.now());
-//                ticketRepository.save(ticket);
-//                log.info("Updated ticket status for ticket ID: {}", ticket.getTicketId());
-//            }
-//        }
+        // 특정 날짜의 티켓을 가져오고, 상태가 CONFIRMED가 아닌 경우
+        List<Ticket> tickets = ticketRepository.findTicketsByMatchDateAndStatus(midnightToday, TicketStatus.CONFIRMED);
 
+        for (Ticket ticket : tickets) {
+            if (ticket.getTicketStatus() == TicketStatus.BOOKED) {
+                ticket.setTicketStatus(TicketStatus.CONFIRMED);
+                ticket.setTicketUpdateAt(LocalDateTime.now());
+                ticketRepository.save(ticket);
+                log.info("Updated ticket status for ticket ID: {}", ticket.getTicketId());
+            }
+        }
     }
 }

--- a/backend/src/main/java/com/team/MMSValleyBall/service/AutoStatusSystemService.java
+++ b/backend/src/main/java/com/team/MMSValleyBall/service/AutoStatusSystemService.java
@@ -69,7 +69,7 @@ public class AutoStatusSystemService {
 
         // 특정 날짜의 티켓을 가져오고, 상태가 CONFIRMED가 아닌 경우
         List<Ticket> tickets = ticketRepository.findTicketsByMatchDateAndStatus(midnightToday, TicketStatus.CONFIRMED);
-
+        System.out.println("ticket match date : " + tickets);
         for (Ticket ticket : tickets) {
             if (ticket.getTicketStatus() == TicketStatus.BOOKED) {
                 ticket.setTicketStatus(TicketStatus.CONFIRMED);

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -13,12 +13,12 @@ spring:
 
   sql:
     init:
-      mode: always
+      mode: never
 
   jpa:
     defer-datasource-initialization: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       format_sql: true
     show-sql: true


### PR DESCRIPTION
1. ticketStatus가 confirmed가 아닌 레코드 찾기를 쿼리로 변경
2. membershipSales, payment, ticket의 상태가 purchase, completed, booked 상태인 경우에 confirmed으로 수정